### PR TITLE
pixmap resize: sampling at correct destination pixel location

### DIFF
--- a/engine/source/workshop.core/drawing/pixmap.cpp
+++ b/engine/source/workshop.core/drawing/pixmap.cpp
@@ -694,7 +694,7 @@ std::unique_ptr<pixmap> pixmap::resize(size_t width, size_t height, pixmap_filte
     {
         for (size_t dst_x = 0; dst_x < width; dst_x++)
         {
-            color filtered_color = sample(dst_x / scale_factor_x, dst_y / scale_factor_y, filter);
+            color filtered_color = sample((dst_x / scale_factor_x) + scale_factor_x, (dst_y / scale_factor_y) + scale_factor_y, filter);
             new_pixmap->set(dst_x, dst_y, filtered_color);
         }
     }


### PR DESCRIPTION
old code w scalefactor 0.5 for mip calculation , would sample the higher res map at (i,j) / 0.5 == 2*i,2*j, which will be integer as well. but it should sample inbetween pixels for the filtering to do something.
for the mip maps it should be sampling at the intersection between the 4 pixels. so at (0.5,0.5) offset from that integer coordinate.
but the offset should work for all scalefactors, not just 0.5